### PR TITLE
Check and Update Go Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.0
+          go-version: 1.25.0
           cache-dependency-path: go.sum
       - name: Setup
         run: make setup

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluegreenhq/dogubako
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-sql-driver/mysql v1.9.2


### PR DESCRIPTION
Updated go.mod and CI workflow to use Go 1.25.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development toolchain and continuous integration environment to use a newer Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->